### PR TITLE
Merge cache feature to the master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
   "name": "chob",
-  "version": "0.6",
+  "version": "0.8",
   "description": "An universal app search tool for Linux",
   "main": "./build/src/cli.js",
   "bin": {
     "chob": "./build/src/cli.js"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^13.0.0",
-    "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^8.0.1",
     "@types/jest": "^26.0.0",
     "@types/node": "14.0.13",
     "@types/node-fetch": "^2.5.7",
@@ -17,7 +14,6 @@
     "pkg": "^4.4.8",
     "prettier": "2.0.5",
     "rimraf": "^3.0.2",
-    "rollup-plugin-node-resolve": "^5.2.0",
     "ts-jest": "~26.1.0",
     "tslib": "^2.0.0",
     "tslint": "6.1.2",

--- a/src/GithubApi.ts
+++ b/src/GithubApi.ts
@@ -1,11 +1,12 @@
 import { IGithubLatestReleases, ITags } from './dataStructure';
 import { ApiClient } from './apiClient';
 
-const apiClient = new ApiClient();
+
 export class GithubApi {
   private repoUrl: string;
   private userName: string;
   private userRepo: string;
+  private apiClient
   private githubApi: string = 'https://api.github.com';
   private userAgent: string =
     'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36';
@@ -13,6 +14,7 @@ export class GithubApi {
   constructor(repoUrl: string) {
     this.userName = repoUrl.split('/')[3];
     this.userRepo = repoUrl.split('/')[4];
+    this.apiClient = new ApiClient()
   }
   async getTheLatestRelease(): Promise<IGithubLatestReleases> {
     const { githubApi, userName, userRepo, userAgent } = this;
@@ -23,7 +25,7 @@ export class GithubApi {
         'User-Agent': userAgent,
       },
     };
-    const request: Response = await apiClient.get(this.repoUrl, options);
+    const request: Response = await this.apiClient.get(this.repoUrl, options);
     const data = await request.json() 
     return data;
   }
@@ -37,7 +39,7 @@ export class GithubApi {
         'User-Agent': userAgent,
       },
     };
-    const request: Response = await apiClient.get(this.repoUrl, options);
+    const request: Response = await this.apiClient.get(this.repoUrl, options);
     const data = await request.json() 
 
     return data

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -10,6 +10,8 @@ import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
 import { pipeline } from 'stream'
+import { cacheFeature } from './cli';
+import CacheManager from './cacheManager';
 const streamPipeline = util.promisify(pipeline)
 
 
@@ -48,7 +50,7 @@ export class ApiClient {
     if (fs.existsSync(filePath)) {
       errorMessage(`You already have downloaded this file in ${homeFolder}`);
       return false;
-    } 
+    }
     fs.writeFileSync(filePath, '');
 
     const file = fs.createWriteStream(filePath);
@@ -72,6 +74,13 @@ export class ApiClient {
   grabDataFromFlathub(): Promise<flathubStructure[]> {
     return new Promise(async (resolve, reject) => {
 
+      if (cacheFeature) {
+        const cacheManager = new CacheManager()
+        const { flathubData } = cacheManager.getSourcesFromCache()
+
+        return resolve(flathubData)
+      }
+
       this.get(this.flathubApi).then(resp => {
         return resp.json()
       }).then(json => {
@@ -87,6 +96,13 @@ export class ApiClient {
   grabDataFromSnap(): Promise<snapStrucuure> {
     return new Promise((resolve, reject) => {
 
+      if (cacheFeature) {
+        const cacheManager = new CacheManager()
+        const { snapData } = cacheManager.getSourcesFromCache()
+
+        return resolve(snapData)
+      }
+
       this.get(this.snapApi).then(resp => {
         return resp.json()
       }).then(json => {
@@ -101,6 +117,13 @@ export class ApiClient {
 
   grabDataAppImage(): Promise<appimageStructure> {
     return new Promise((resolve, reject) => {
+
+      if (cacheFeature) {
+        const cacheManager = new CacheManager()
+        const { appimageData } = cacheManager.getSourcesFromCache()
+
+        return resolve(appimageData)
+      }
 
       this.get(this.appimageApi).then(resp => {
         return resp.json()

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -12,8 +12,10 @@ import * as util from 'util';
 import { pipeline } from 'stream'
 import { cacheFeature } from './cli';
 import CacheManager from './cacheManager';
-const streamPipeline = util.promisify(pipeline)
 
+
+const streamPipeline = util.promisify(pipeline)
+const cacheManager = new CacheManager()
 
 
 export class ApiClient {
@@ -75,7 +77,6 @@ export class ApiClient {
     return new Promise(async (resolve, reject) => {
 
       if (cacheFeature) {
-        const cacheManager = new CacheManager()
         const { flathubData } = cacheManager.getSourcesFromCache()
 
         return resolve(flathubData)
@@ -97,7 +98,6 @@ export class ApiClient {
     return new Promise((resolve, reject) => {
 
       if (cacheFeature) {
-        const cacheManager = new CacheManager()
         const { snapData } = cacheManager.getSourcesFromCache()
 
         return resolve(snapData)
@@ -119,7 +119,6 @@ export class ApiClient {
     return new Promise((resolve, reject) => {
 
       if (cacheFeature) {
-        const cacheManager = new CacheManager()
         const { appimageData } = cacheManager.getSourcesFromCache()
 
         return resolve(appimageData)

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -32,7 +32,7 @@ export class ApiClient {
   constructor() {
     this.cacheManager = new CacheManager()
 
-    if (!this.cacheManager.hasCachedSources) {
+    if (cacheFeature && !this.cacheManager.hasCachedSources) {
       errorMessage('⚡ Could not find any cached sources, your search will be cached after this results.')
     }
 

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,4 +1,4 @@
-import { errorMessage, successfullMessage } from './main';
+import { errorMessage, successfullMessage } from './helpers';
 const fetch = require('node-fetch').default
 import {
   flathubStructure,
@@ -11,11 +11,11 @@ import * as path from 'path';
 import * as util from 'util';
 import { pipeline } from 'stream'
 import { cacheFeature } from './cli';
-import CacheManager from './cacheManager';
+import  CacheManager, { ICacheManager } from './cacheManager';
 
 
 const streamPipeline = util.promisify(pipeline)
-const cacheManager = new CacheManager()
+
 
 
 export class ApiClient {
@@ -27,6 +27,16 @@ export class ApiClient {
   private flathubData;
   private snapData;
   private appimageData;
+  private cacheManager: ICacheManager;
+
+  constructor() {
+    this.cacheManager = new CacheManager()
+
+    if (!this.cacheManager.hasCachedSources) {
+      errorMessage('⚡ Could not find any cached sources, your search will be cached after this results.')
+    }
+
+  }
 
   async get(url: string, options: Object = {}): Promise<Response> {
     return new Promise(async (resolve, reject) => {
@@ -76,8 +86,8 @@ export class ApiClient {
   grabDataFromFlathub(): Promise<flathubStructure[]> {
     return new Promise(async (resolve, reject) => {
 
-      if (cacheFeature) {
-        const { flathubData } = cacheManager.getSourcesFromCache()
+      if (cacheFeature && this.cacheManager.hasCachedSources) {
+        const { flathubData } = this.cacheManager.getSourcesFromCache()
 
         return resolve(flathubData)
       }
@@ -97,8 +107,8 @@ export class ApiClient {
   grabDataFromSnap(): Promise<snapStrucuure> {
     return new Promise((resolve, reject) => {
 
-      if (cacheFeature) {
-        const { snapData } = cacheManager.getSourcesFromCache()
+      if (cacheFeature && this.cacheManager.hasCachedSources) {
+        const { snapData } = this.cacheManager.getSourcesFromCache()
 
         return resolve(snapData)
       }
@@ -117,9 +127,8 @@ export class ApiClient {
 
   grabDataAppImage(): Promise<appimageStructure> {
     return new Promise((resolve, reject) => {
-
-      if (cacheFeature) {
-        const { appimageData } = cacheManager.getSourcesFromCache()
+      if (cacheFeature && this.cacheManager.hasCachedSources) {
+        const { appimageData } = this.cacheManager.getSourcesFromCache()
 
         return resolve(appimageData)
       }

--- a/src/cacheManager.ts
+++ b/src/cacheManager.ts
@@ -2,6 +2,7 @@ import * as path from 'path'
 import * as os from 'os'
 import * as fs from 'fs'
 import { flathubStructure, snapStrucuure, appimageStructure } from './dataStructure'
+import { updateInterval } from './cli'
 
 
 interface ICacheManager {
@@ -25,13 +26,14 @@ export default class CacheManager implements ICacheManager {
     private updatedAtFilePath: string
     private updateCacheInterval: number
 
+
     constructor() {
         this.cacheLocation = path.resolve(os.homedir(), 'chob');
         this.flathubCachePath = path.resolve(this.cacheLocation, '.flathub.json');
         this.snapCachePath = path.resolve(this.cacheLocation, '.snap.json');
         this.appimageCachePath = path.resolve(this.cacheLocation, '.appimage.json');
         this.updatedAtFilePath = path.resolve(this.cacheLocation, '.updatedAt');
-        this.updateCacheInterval = 1
+        this.updateCacheInterval = updateInterval
 
         if (!this.checkCacheFiles()) {
             this.createCacheFiles()

--- a/src/cacheManager.ts
+++ b/src/cacheManager.ts
@@ -1,0 +1,119 @@
+import * as path from 'path'
+import * as os from 'os'
+import * as fs from 'fs'
+import { flathubStructure, snapStrucuure, appimageStructure } from './dataStructure'
+
+
+interface ICacheManager {
+    shouldUpdateCache: () => boolean
+    updateCache: (data: IUpdateCacheObject) => boolean | Error
+    getSourcesFromCache: () => IUpdateCacheObject
+}
+
+interface IUpdateCacheObject extends Object {
+    flathubData: flathubStructure[]
+    snapData: snapStrucuure
+    appimageData: appimageStructure
+}
+
+export default class CacheManager implements ICacheManager {
+
+    private cacheLocation: string
+    private flathubCachePath: string
+    private snapCachePath: string
+    private appimageCachePath: string
+    private updatedAtFilePath: string
+    private updateCacheInterval: number
+
+    constructor() {
+        this.cacheLocation = path.resolve(os.homedir(), 'chob');
+        this.flathubCachePath = path.resolve(this.cacheLocation, '.flathub.json');
+        this.snapCachePath = path.resolve(this.cacheLocation, '.snap.json');
+        this.appimageCachePath = path.resolve(this.cacheLocation, '.appimage.json');
+        this.updatedAtFilePath = path.resolve(this.cacheLocation, '.updatedAt');
+        this.updateCacheInterval = 1
+
+        if (!this.checkCacheFiles()) {
+            this.createCacheFiles()
+        }
+
+    }
+
+    getSourcesFromCache(): IUpdateCacheObject {
+        const flathubData: flathubStructure[] = JSON.parse(fs.readFileSync(this.flathubCachePath).toString())
+        const snapData: snapStrucuure = JSON.parse(fs.readFileSync(this.snapCachePath).toString())
+        const appimageData: appimageStructure = JSON.parse(fs.readFileSync(this.appimageCachePath).toString())
+
+        return {
+            flathubData,
+            snapData,
+            appimageData
+        }
+    }
+
+
+    updateCache(data: IUpdateCacheObject): boolean | Error {
+        try {
+            const { flathubData, snapData, appimageData } = data
+
+            fs.writeFileSync(this.flathubCachePath, JSON.stringify(flathubData))
+            fs.writeFileSync(this.snapCachePath, JSON.stringify(snapData))
+            fs.writeFileSync(this.appimageCachePath, JSON.stringify(appimageData))
+            fs.writeFileSync(this.updatedAtFilePath, Date.now().toString())
+            return true
+
+        } catch (err) {
+            throw new Error(err)
+        }
+    }
+
+    shouldUpdateCache() {
+        const date = Number(fs.readFileSync(this.updatedAtFilePath).toString())
+        const tomorrowDate = new Date(date).setDate(new Date(date).getDate() + this.updateCacheInterval)
+
+        if (!date) {
+            return true
+        }
+
+        if (tomorrowDate < Date.now()) {
+            return true
+        }
+
+        return false
+
+
+    }
+
+
+    private checkCacheFiles(): boolean {
+        const flathubFile = fs.existsSync(this.flathubCachePath)
+        const snapFile = fs.existsSync(this.snapCachePath)
+        const appimageFile = fs.existsSync(this.appimageCachePath)
+        const updateFile = fs.existsSync(this.updatedAtFilePath)
+
+        if (flathubFile && snapFile && appimageFile && updateFile) {
+            return true
+        }
+
+        return false
+
+    }
+
+    private createCacheFiles(): boolean | Error {
+        try {
+            const data = JSON.stringify({})
+            fs.writeFileSync(this.flathubCachePath, data)
+            fs.writeFileSync(this.snapCachePath, data)
+            fs.writeFileSync(this.appimageCachePath, data)
+            fs.writeFileSync(this.updatedAtFilePath, '')
+
+
+            return true
+        } catch (err) {
+            throw new Error('Could not create cache files!')
+        }
+    }
+
+
+
+}

--- a/src/cacheManager.ts
+++ b/src/cacheManager.ts
@@ -21,8 +21,8 @@ interface IUpdateCacheObject extends Object {
 }
 
 interface IConfig extends Object {
-    enabled: boolean
-    interval: number
+    cacheEnabled: boolean
+    chacheUpdateInterval: number
 }
 
 export default class CacheManager implements ICacheManager {
@@ -57,8 +57,8 @@ export default class CacheManager implements ICacheManager {
         }
 
         this.config = this.parseConfig()
-        this.isCacheEnabled = this.config.enabled
-        this.updateCacheInterval = this.config.interval || 1
+        this.isCacheEnabled = this.config.cacheEnabled
+        this.updateCacheInterval = this.config.chacheUpdateInterval || 1
 
 
         this.hasCachedSources = this.checkHasCachedSources()
@@ -67,7 +67,7 @@ export default class CacheManager implements ICacheManager {
     }
 
     updateInterval(interval: number): boolean {
-        this.config.interval = interval
+        this.config.chacheUpdateInterval = interval
 
         try {
             fs.writeFileSync(this.configPath, JSON.stringify(this.config))
@@ -78,7 +78,7 @@ export default class CacheManager implements ICacheManager {
     }
 
     updateCacheStatment(statment: boolean): boolean {
-        this.config.enabled = statment
+        this.config.cacheEnabled = statment
         try {
             fs.writeFileSync(this.configPath, JSON.stringify(this.config))
             return true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,16 @@
 import * as argparser from 'commander';
-import * as colors from 'colors';
 import { grabApplicationsFromApi, search } from './main';
 import * as pkg from '../package.json';
-
+import { infoMessage } from './helpers';
+import * as colors from 'colors';
 export let experimentalFeatures: boolean = false;
 export let cacheFeature: boolean = false
 export let updateInterval: number = 1
 
+
 const helpText = () => colors.bgCyan.white.bold('Usage: chob pkgName');
 const searchApplication = appName => {
-  console.log(
-    colors.bgGreen.white.bold(`🔎 Searching ${appName} on repositories.`),
-  );
+  infoMessage(`🔎 Searching ${appName} on repositories.`)
   grabApplicationsFromApi().then(() => {
     search(appName.toLowerCase());
   });
@@ -36,7 +35,6 @@ if (args.length < 1) {
   if (argparser.enableExperiementalFeatures) {
     experimentalFeatures = true;
   }
-  console.log(argparser.updateInterval)
 
   if (argparser.updateInterval) {
     updateInterval = argparser.updateInterval;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import * as pkg from '../package.json';
 
 export let experimentalFeatures: boolean = false;
 export let cacheFeature: boolean = false
+export let updateInterval: number = 1
 
 const helpText = () => colors.bgCyan.white.bold('Usage: chob pkgName');
 const searchApplication = appName => {
@@ -19,7 +20,7 @@ const searchApplication = appName => {
 argparser
   .option('--enableExperiementalFeatures', 'Enables experiemental features')
   .option('--enableCache', 'Enables feature')
-  .option('--force', 'Force action')
+  .option('--updateInterval <number>', 'Update the cache in interval (Number expected. It will count as days.) ')
 
 
 argparser.version(pkg.version);
@@ -31,9 +32,14 @@ if (args.length < 1) {
   argparser.outputHelp(helpText);
 } else {
   const appName = argparser.args[0]
-
+  
   if (argparser.enableExperiementalFeatures) {
     experimentalFeatures = true;
+  }
+  console.log(argparser.updateInterval)
+
+  if (argparser.updateInterval) {
+    updateInterval = argparser.updateInterval;
   }
 
   if (argparser.enableCache) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,6 @@ import * as pkg from '../package.json';
 
 export let experimentalFeatures: boolean = false;
 export let cacheFeature: boolean = false
-export let forceAction: boolean = false
 
 const helpText = () => colors.bgCyan.white.bold('Usage: chob pkgName');
 const searchApplication = appName => {
@@ -41,12 +40,6 @@ if (args.length < 1) {
     cacheFeature = true;
   }
   
-  if (argparser.force) {
-    forceAction = true;
-  }
-
-  
-
   searchApplication(appName);
 
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,9 +3,11 @@ import { grabApplicationsFromApi, search } from './main';
 import * as pkg from '../package.json';
 import { infoMessage } from './helpers';
 import * as colors from 'colors';
+
 export let experimentalFeatures: boolean = false;
 export let cacheFeature: boolean = false
 export let updateInterval: number = 1
+export let forceUpdateCache: boolean = false
 
 
 const helpText = () => colors.bgCyan.white.bold('Usage: chob pkgName');
@@ -20,7 +22,7 @@ argparser
   .option('--enableExperiementalFeatures', 'Enables experiemental features')
   .option('--enableCache', 'Enables feature')
   .option('--updateInterval <number>', 'Update the cache in interval (Number expected. It will count as days.) ')
-
+  .option('--forceUpdateCache', 'Forcing cache to be up to dated.')
 
 argparser.version(pkg.version);
 argparser.parse(process.argv);
@@ -30,7 +32,7 @@ const args = process.argv.slice(2)
 if (args.length < 1) {
   argparser.outputHelp(helpText);
 } else {
-  const appName = argparser.args[0]
+  let appName = argparser.args[0]
   
   if (argparser.enableExperiementalFeatures) {
     experimentalFeatures = true;
@@ -44,6 +46,12 @@ if (args.length < 1) {
     cacheFeature = true;
   }
   
+  if(argparser.forceUpdateCache) {
+    appName = 'updating' 
+    cacheFeature = true
+    forceUpdateCache = true    
+  }
+
   searchApplication(appName);
 
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,8 @@ import { grabApplicationsFromApi, search } from './main';
 import * as pkg from '../package.json';
 
 export let experimentalFeatures: boolean = false;
-
+export let cacheFeature: boolean = false
+export let forceAction: boolean = false
 
 const helpText = () => colors.bgCyan.white.bold('Usage: chob pkgName');
 const searchApplication = appName => {
@@ -18,18 +19,12 @@ const searchApplication = appName => {
 
 argparser
   .option('--enableExperiementalFeatures', 'Enables experiemental features')
-
-
-
+  .option('--enableCache', 'Enables feature')
+  .option('--force', 'Force action')
 
 
 argparser.version(pkg.version);
 argparser.parse(process.argv);
-
-
-
-
-// console.log(argparser.enableExperiementalFeatures)
 
 const args = process.argv.slice(2)
 
@@ -37,9 +32,21 @@ if (args.length < 1) {
   argparser.outputHelp(helpText);
 } else {
   const appName = argparser.args[0]
+
   if (argparser.enableExperiementalFeatures) {
     experimentalFeatures = true;
   }
+
+  if (argparser.enableCache) {
+    cacheFeature = true;
+  }
+  
+  if (argparser.force) {
+    forceAction = true;
+  }
+
+  
+
   searchApplication(appName);
 
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,14 +1,15 @@
 import * as argparser from 'commander';
 import { grabApplicationsFromApi, search } from './main';
 import * as pkg from '../package.json';
-import { infoMessage } from './helpers';
+import { infoMessage, successfullMessage } from './helpers';
 import * as colors from 'colors';
+import CacheManager from './cacheManager';
 
+const cache = new CacheManager()
 export let experimentalFeatures: boolean = false;
-export let cacheFeature: boolean = false
+export let cacheFeature: boolean = cache.isCacheEnabled || false
 export let updateInterval: number = 1
 export let forceUpdateCache: boolean = false
-
 
 const helpText = () => colors.bgCyan.white.bold('Usage: chob pkgName');
 const searchApplication = appName => {
@@ -20,7 +21,8 @@ const searchApplication = appName => {
 
 argparser
   .option('--enableExperiementalFeatures', 'Enables experiemental features')
-  .option('--enableCache', 'Enables feature')
+  .option('--enableCache', 'Enables cache feature')
+  .option('--disableCache', 'Disables cache feature')
   .option('--updateInterval <number>', 'Update the cache in interval (Number expected. It will count as days.) ')
   .option('--forceUpdateCache', 'Forcing cache to be up to dated.')
 
@@ -40,10 +42,19 @@ if (args.length < 1) {
 
   if (argparser.updateInterval) {
     updateInterval = argparser.updateInterval;
+    successfullMessage('⚡ Updated cache updating interval with ' + updateInterval)
+    cache.updateInterval(updateInterval)
   }
 
   if (argparser.enableCache) {
+    successfullMessage('⚡ Your cache will now be enabled.')
     cacheFeature = true;
+    cache.updateCacheStatment(true)
+  }
+  
+  if (argparser.disableCache) {
+    successfullMessage('⚡ Your cache will now be disabled.')
+    cache.updateCacheStatment(false)
   }
   
   if(argparser.forceUpdateCache) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,7 @@
+import * as colors from 'colors';
+
+
+export const successfullMessage = message =>
+  console.log(colors.bgGreen.white.bold(message));
+export const errorMessage = message => console.log(colors.bgRed.white.bold(message));
+export const infoMessage = message => console.log(colors.bgBlue.white.bold(message));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { defaultStructure } from './dataStructure';
 import { GithubApi } from './GithubApi';
-import { experimentalFeatures, cacheFeature, forceAction } from './cli';
+import { experimentalFeatures, cacheFeature } from './cli';
 import { ApiClient } from './apiClient';
 import {
   serializeSnapData,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { defaultStructure } from './dataStructure';
 import { GithubApi } from './GithubApi';
 import { experimentalFeatures, cacheFeature } from './cli';
+import { errorMessage, infoMessage, successfullMessage } from './helpers'
 import { ApiClient } from './apiClient';
 import {
   serializeSnapData,
@@ -8,16 +9,11 @@ import {
   serializeFlathubData,
 } from './dataSerializer';
 import * as open from 'opener';
-import * as colors from 'colors';
 import * as prompt from 'prompts';
 import { TYPES, getTypeNm } from './types';
 import CacheManager from './cacheManager';
 
 let applicationList: Array<Object> = [];
-export const successfullMessage = message =>
-  console.log(colors.bgGreen.white.bold(message));
-export const errorMessage = message => console.log(colors.bgRed.white.bold(message));
-const infoMessage = message => console.log(colors.bgBlue.white.bold(message));
 
 function updateApplicationList(applications: Array<Object>): void {
   applicationList = applications;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { defaultStructure } from './dataStructure';
 import { GithubApi } from './GithubApi';
-import { experimentalFeatures, cacheFeature } from './cli';
+import { experimentalFeatures, cacheFeature, forceUpdateCache } from './cli';
 import { errorMessage, infoMessage, successfullMessage } from './helpers'
 import { ApiClient } from './apiClient';
 import {
@@ -125,7 +125,7 @@ export function grabApplicationsFromApi() {
           snapData
         }
 
-        if (cacheManager.shouldUpdateCache()) {
+        if (cacheManager.shouldUpdateCache() || forceUpdateCache) {
           cacheManager.updateCache(updateCache)
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,11 @@ export function grabApplicationsFromApi() {
     try {
       const apiClient = new ApiClient();
 
+      if(!cacheFeature) {
+        infoMessage('\n ⚡ Complaining about slow search results? Try caching results by adding --enableCache argument at the end of your command! \n')
+      }
+
+
       infoMessage('Searching on AppImage feed..');
       const appimageData = await apiClient.grabDataAppImage();
       let serializedData = serializeAppImageData(appimageData);

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,48 +485,6 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@rollup/plugin-commonjs@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-13.0.0.tgz#8a1d684ba6848afe8b9e3d85649d4b2f6f7217ec"
-  integrity sha512-Anxc3qgkAi7peAyesTqGYidG5GRim9jtg8xhmykNaZkImtvjA7Wsqep08D2mYsqw1IF7rA3lYfciLgzUSgRoqw==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    commondir "^1.0.1"
-    estree-walker "^1.0.1"
-    glob "^7.1.2"
-    is-reference "^1.1.2"
-    magic-string "^0.25.2"
-    resolve "^1.11.0"
-
-"@rollup/plugin-json@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
-  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-
-"@rollup/plugin-node-resolve@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.0.1.tgz#364b5938808ee6b5164dea5ef7291be3f7395199"
-  integrity sha512-KIeAmueDDaYMqMBnUngLVVZhURwxA12nq/YB6nGm5/JpVyOMwI1fCVU3oL/dAnnLBG7oiPXntO5LHOiMrfNXCA==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    deep-freeze "^0.0.1"
-    deepmerge "^4.2.2"
-    is-module "^1.0.0"
-    resolve "^1.14.2"
-
-"@rollup/pluginutils@^3.0.8":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
-  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
-  dependencies:
-    "@types/estree" "0.0.39"
-    estree-walker "^1.0.1"
-    picomatch "^2.2.2"
-
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -578,16 +536,6 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
-"@types/estree@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-
-"@types/estree@0.0.44":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.44.tgz#980cc5a29a3ef3bea6ff1f7d021047d7ea575e21"
-  integrity sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
@@ -646,13 +594,6 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.1.tgz#b6e98083f13faa1e5231bfa3bdb1b0feff536b6d"
   integrity sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==
-
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
-  dependencies:
-    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1283,11 +1224,6 @@ builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-builtin-modules@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
-  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -1741,11 +1677,6 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-deep-freeze@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
-  integrity sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -1980,16 +1911,6 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
-
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
-estree-walker@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
-  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2799,11 +2720,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-module@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
-  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
-
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -2827,13 +2743,6 @@ is-potential-custom-element-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
-
-is-reference@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.0.tgz#d938b0cf85a0df09849417b274f02fb509293599"
-  integrity sha512-ZVxq+5TkOx6GQdnoMm2aRdCKADdcrOWXLGzGT+vIA8DMpqEJaRk5AL1bS80zJ2bjHunVmjdzfCt0e4BymIEqKQ==
-  dependencies:
-    "@types/estree" "0.0.44"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -3530,13 +3439,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-magic-string@^0.25.2:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
-  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
-  dependencies:
-    sourcemap-codec "^1.4.4"
-
 make-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -4147,7 +4049,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -4555,7 +4457,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -4593,24 +4495,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-rollup-plugin-node-resolve@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
-  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  dependencies:
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.11.1"
-    rollup-pluginutils "^2.8.1"
-
-rollup-pluginutils@^2.8.1:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -4849,11 +4733,6 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
-
-sourcemap-codec@^1.4.4:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
-  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
As all of you know getting data from three diffrent apis takes some time, and for each search no one wants to bother with that wait time. So i come up with caching the api endpoint solution which makes search very very fast and you can now search while you are offline(I know you won't need it if you don't have any network connection. But hey, it's a feature not a bug)

To be able to use it you need to add --enableCache argument at the end of the command

Like this:
``` ./chob vlc --enableCache ```

So this will create a chob folder on your home directory which contains 4 diffrent files. 3 for api endpoints and 1 is for updating the cache based on interval. 

By default updating the cache value is 1 day, you can change it by adding updateInterval argument like this:

 ``` ./chob vlc --enableCache --updateInterval 7 ```
This will update .updateAt file to update your api endpoint caches every 7 days. 


Here is a comparision:
![](https://imgur.com/wjIrs8I.gif)


# Changelog
* Added cache manager to cache api endpoints for faster search
* Asks user before downloading the appimage
* Bug fixes
